### PR TITLE
Promoting `short_name` to `name`

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -1,7 +1,6 @@
 ---
-name: Testing Grouplet
 full_name: 18F Testing Grouplet
-short_name: testing
+name: testing
 type: docs
 owner_type: working-group
 status: active


### PR DESCRIPTION
Removed original value for `name`

See: #16 , cc @mbland 
